### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -435,6 +435,9 @@ function mergeLight(/* target, ...sources */) {
 				target = Array.isArray(source) ? Array(source.length) : {};
 			}
 			for (key in source) {
+				if (isPrototypePolluted(key)) {
+					continue;
+				}
 				value = source[key];
 				if (value !== undefined) {
 					target[key] = mergeLight(target[key], value);
@@ -808,4 +811,16 @@ function isEmpty(val) {
 	}
 	return true;
 }
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * 
+ * @method isPrototypePolluted
+ * @param {string} key - key to check
+ * @return {Boolean}
+ */
+function isPrototypePolluted(key) {
+	return [ '__proto__', 'constructor', 'prototype' ].includes(key);
+}
+
 exports.isEmpty = isEmpty;

--- a/lib/index.js
+++ b/lib/index.js
@@ -346,7 +346,7 @@ function setPath(obj, path, value) {
 	var i;
 	for (i = 0; i < parts.length; i++) {
 		if (isPrototypePolluted(parts[i])) {
-		    continue;
+		    	continue;
 		}
 		if (i === parts.length - 1) {
 			cur[parts[i]] = value;

--- a/lib/index.js
+++ b/lib/index.js
@@ -346,7 +346,7 @@ function setPath(obj, path, value) {
 	var i;
 	for (i = 0; i < parts.length; i++) {
 		if (isPrototypePolluted(parts[i])) {
-		    	continue;
+		    continue;
 		}
 		if (i === parts.length - 1) {
 			cur[parts[i]] = value;
@@ -373,6 +373,9 @@ function deletePath(obj, path) {
 	var parts = path.split('.');
 	var i;
 	for (i = 0; i < parts.length; i++) {
+		if (isPrototypePolluted(parts[i])) {
+			continue;
+		}
 		if (i === parts.length - 1) {
 			delete cur[parts[i]];
 		} else {
@@ -409,7 +412,7 @@ function getPath(obj, path, allowSkipArrays) {
 			cur = cur[0];
 			i--;
 		} else {
-			cur = cur[parts[i]];
+			cur =  isPrototypePolluted(parts[i]) ? {} : cur[parts[i]];
 		}
 	}
 	return cur;

--- a/lib/index.js
+++ b/lib/index.js
@@ -345,6 +345,9 @@ function setPath(obj, path, value) {
 	var parts = path.split('.');
 	var i;
 	for (i = 0; i < parts.length; i++) {
+		if (isPrototypePolluted(parts[i])) {
+		    continue;
+		}
 		if (i === parts.length - 1) {
 			cur[parts[i]] = value;
 		} else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -412,7 +412,7 @@ function getPath(obj, path, allowSkipArrays) {
 			cur = cur[0];
 			i--;
 		} else {
-			cur =  isPrototypePolluted(parts[i]) ? {} : cur[parts[i]];
+			cur = isPrototypePolluted(parts[i]) ? {} : cur[parts[i]];
 		}
 	}
 	return cur;
@@ -820,7 +820,7 @@ function isEmpty(val) {
 
 /**
  * Blacklist certain keys to prevent Prototype Pollution
- * 
+ *
  * @method isPrototypePolluted
  * @param {string} key - key to check
  * @return {Boolean}

--- a/lib/index.js
+++ b/lib/index.js
@@ -346,7 +346,7 @@ function setPath(obj, path, value) {
 	var i;
 	for (i = 0; i < parts.length; i++) {
 		if (isPrototypePolluted(parts[i])) {
-		    continue;
+			continue;
 		}
 		if (i === parts.length - 1) {
 			cur[parts[i]] = value;

--- a/test/base-functions.js
+++ b/test/base-functions.js
@@ -451,6 +451,12 @@ describe('Base Functions', function() {
 			let result = objtools.merge({}, obj);
 			expect(result.foo).to.equal(obj.foo);
 		});
+		it('should not allow prototype pollution', () => {
+			const data = objtools.merge({}, JSON.parse('{"__proto__": {"polluted": true}}'));
+			expect(data.polluted).to.equal(undefined);
+			expect({}.polluted).to.equal(undefined);
+			expect(data.polluted).to.not.equal(true);
+		});
 	});
 
 	describe('getDuplicates()', function() {

--- a/test/base-functions.js
+++ b/test/base-functions.js
@@ -289,6 +289,9 @@ describe('Base Functions', function() {
 		it('getPath should handle root path', function() {
 			expect(objtools.getPath(obj1, null)).to.deep.equal(obj1);
 		});
+		it('getPath should not fetch object prototype', function() {
+			expect(objtools.getPath(obj1, '__proto__')).to.not.equal(Object.prototype);
+		});
 		it('setPath should set various paths', function() {
 			objtools.setPath(obj1, 'foo', 'biz');
 			expect(obj1.foo).to.equal('biz');
@@ -303,9 +306,17 @@ describe('Base Functions', function() {
 			objtools.setPath(obj1, 'baz.arr.1.buz', 11);
 			expect(obj1.baz.arr[1]).to.deep.equal({ buz: 11 });
 		});
+		it('setPath should not pollute prototype', function() {
+			objtools.setPath(obj1, '__proto__.polluted', true);
+			expect({}.polluted).to.equal(undefined);
+		});
 		it('deletePath should delete paths', function() {
 			objtools.deletePath(obj1, 'baz.arr');
 			expect(obj1.baz.arr).to.equal(undefined);
+		});
+		it('deletePath should not pollute prototype', function() {
+			objtools.deletePath(obj1, '__proto__.toString');
+			expect({}.toString).to.not.equal(undefined);
 		});
 	});
 
@@ -451,11 +462,9 @@ describe('Base Functions', function() {
 			let result = objtools.merge({}, obj);
 			expect(result.foo).to.equal(obj.foo);
 		});
-		it('should not allow prototype pollution', () => {
-			const data = objtools.merge({}, JSON.parse('{"__proto__": {"polluted": true}}'));
-			expect(data.polluted).to.equal(undefined);
+		it('should not pollute prototype', () => {
+			objtools.merge({}, JSON.parse('{"__proto__": {"polluted": true}}'));
 			expect({}.polluted).to.equal(undefined);
-			expect(data.polluted).to.not.equal(true);
 		});
 	});
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`objtools` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-objtools

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var objtools = require("objtools")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
objtools.merge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i objtools # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![objtools-fix](https://user-images.githubusercontent.com/43996156/102889200-37f15e80-4480-11eb-8424-416dca89697c.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
